### PR TITLE
Trait sidebar and main trait information

### DIFF
--- a/traitcuration/static/styles/components/buttons/_buttons.scss
+++ b/traitcuration/static/styles/components/buttons/_buttons.scss
@@ -1,5 +1,16 @@
 @import "../../utilities/variables";
 
+.button {
+  box-shadow: 2px 2px rgba(0, 0, 0, 0.1) !important;
+
+  &--success {
+    background-color: $color-success !important;
+
+    &:active {
+      background-color: darken($color-success, 5%) !important;
+    }
+  }
+}
 .button-outlined {
   background-color: white !important;
   color: $color-gray;

--- a/traitcuration/static/styles/layout/layout.scss
+++ b/traitcuration/static/styles/layout/layout.scss
@@ -2,3 +2,4 @@
 
 @import "./footer/footer.scss";
 @import "./header/header.scss";
+@import "./sidebar/sidebar"

--- a/traitcuration/static/styles/layout/layout.scss
+++ b/traitcuration/static/styles/layout/layout.scss
@@ -1,5 +1,5 @@
 /* Styling for layout components */
 
-@import "./footer/footer.scss";
-@import "./header/header.scss";
+@import "./footer/footer";
+@import "./header/header";
 @import "./sidebar/sidebar"

--- a/traitcuration/static/styles/layout/sidebar/_sidebar.scss
+++ b/traitcuration/static/styles/layout/sidebar/_sidebar.scss
@@ -19,36 +19,23 @@
   }
 
   &__section {
-<<<<<<< HEAD
-=======
-    margin-bottom: 0.3rem;
->>>>>>> 6f49d3d7d78961812843b07ad40473cebd162841
-    
-      &-title{
-        margin-bottom: 0.6rem !important;
-      }
-    
-      &-text{
-        font-family: $lato-bold !important;
-      }
+    &-title {
+      margin-bottom: 0.6rem !important;
+    }
 
-      &-review-button {
-        display: flex !important;
-        padding: 0.5rem 1.2rem !important;
-        align-items: center !important;
-<<<<<<< HEAD
-        margin-top: 1.5rem !important;
-      }
+    &-text {
+      font-family: $lato-bold !important;
+    }
+
+    &-review-button {
+      display: flex !important;
+      padding: 0.5rem 1.2rem !important;
+      align-items: center !important;
+      margin-top: 1.5rem !important;
+    }
   }
 
   &__review-section {
     margin-bottom: 0.8rem;
   }
-
-=======
-        margin-top: 1rem !important;
-      }
-  }
-
->>>>>>> 6f49d3d7d78961812843b07ad40473cebd162841
 }

--- a/traitcuration/static/styles/layout/sidebar/_sidebar.scss
+++ b/traitcuration/static/styles/layout/sidebar/_sidebar.scss
@@ -19,7 +19,6 @@
   }
 
   &__section {
-    margin-bottom: 0.3rem;
     
       &-title{
         margin-bottom: 0.6rem !important;
@@ -33,8 +32,12 @@
         display: flex !important;
         padding: 0.5rem 1.2rem !important;
         align-items: center !important;
-        margin-top: 1rem !important;
+        margin-top: 1.5rem !important;
       }
+  }
+
+  &__review-section {
+    margin-bottom: 0.8rem;
   }
 
 }

--- a/traitcuration/static/styles/layout/sidebar/_sidebar.scss
+++ b/traitcuration/static/styles/layout/sidebar/_sidebar.scss
@@ -8,7 +8,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   background-color: $color-secondary !important;
-  width: 14.5rem;
+  width: 14vw;
   z-index: 1;
 
   &__wrapper {

--- a/traitcuration/static/styles/layout/sidebar/_sidebar.scss
+++ b/traitcuration/static/styles/layout/sidebar/_sidebar.scss
@@ -1,0 +1,40 @@
+@import "../../utilities/variables";
+
+.sidebar {
+  position: fixed;
+  right: 0;
+  top: 66px;
+  bottom: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: $color-secondary !important;
+  width: 14.5rem;
+  z-index: 1;
+
+  &__wrapper {
+    color: white !important;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__section {
+    margin-bottom: 0.3rem;
+    
+      &-title{
+        margin-bottom: 0.6rem !important;
+      }
+    
+      &-text{
+        font-family: $lato-bold !important;
+      }
+
+      &-review-button {
+        display: flex !important;
+        padding: 0.5rem 1.2rem !important;
+        align-items: center !important;
+        margin-top: 1rem !important;
+      }
+  }
+
+}

--- a/traitcuration/static/styles/libraries/UIKit/_uikit-overwrites.scss
+++ b/traitcuration/static/styles/libraries/UIKit/_uikit-overwrites.scss
@@ -12,5 +12,6 @@
 }
 
 .uk-label {
+  text-align: center;
   border-radius: 10px !important;
 }

--- a/traitcuration/static/styles/main.scss
+++ b/traitcuration/static/styles/main.scss
@@ -3,6 +3,6 @@
 @import "./libraries/libraries";
 @import "./base/base";
 @import "./pages/pages";
-@import "./layout/layout.scss";
+@import "./layout/layout";
 @import "./utilities/utilities";
 @import "./components/components";

--- a/traitcuration/static/styles/main.scss
+++ b/traitcuration/static/styles/main.scss
@@ -1,8 +1,8 @@
 /* Main file to import into the app */
 
+@import "./libraries/libraries";
 @import "./base/base";
 @import "./pages/pages";
 @import "./layout/layout.scss";
-@import "./libraries/libraries";
 @import "./utilities/utilities";
-@import "./components/components"
+@import "./components/components";

--- a/traitcuration/static/styles/pages/_pages.scss
+++ b/traitcuration/static/styles/pages/_pages.scss
@@ -1,6 +1,6 @@
 /* Styling for individual pages */
 
-@import "./homepage/homepage.scss";
-@import "./base/base.scss";
+@import "./homepage/homepage";
+@import "./base/base";
 @import "./browse/browse";
 @import "./trait_detail/trait_detail"

--- a/traitcuration/static/styles/pages/_pages.scss
+++ b/traitcuration/static/styles/pages/_pages.scss
@@ -2,4 +2,5 @@
 
 @import "./homepage/homepage.scss";
 @import "./base/base.scss";
-@import "./browse/browse"
+@import "./browse/browse";
+@import "./trait_detail/trait_detail"

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -1,5 +1,5 @@
 .trait-container {
-    margin-right: 14.5rem;
+    width: 86vw;
 }
 
 .info-section {
@@ -12,6 +12,10 @@
     display: flex;
     flex-direction: column;
     max-width: 40vw;
+
+    @media (max-width: 900px) {
+      max-width: 30vh;
+    }
   }
 
   &__title {

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -8,7 +8,7 @@
   }
 
   &__column {
-    margin-right: 3.5rem;
+    margin-right: 4.2rem;
     display: flex;
     flex-direction: column;
     max-width: 40vw;

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -1,0 +1,24 @@
+.trait-container {
+    margin-right: 14.5rem;
+}
+
+.info-section {
+  &__wrapper {
+    display: flex;
+  }
+
+  &__column {
+    margin-right: 3.5rem;
+    display: flex;
+    flex-direction: column;
+    max-width: 40vw;
+  }
+
+  &__title {
+      color: $color-gray !important;
+  }
+
+  &__value {
+      color: black !important;
+  }
+}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -5,6 +5,37 @@ Trait Detail
 {% endblock %}
 
 {% block content %}
+<aside class="sidebar">
+    <div class="sidebar__wrapper">
+        <div class="sidebar__section">
+            <p class="sidebar__section-title">LAST UPDATED</p>
+            <span class="sidebar__section-text"> {{trait.timestamp_updated}} </span>
+            <hr/>
+        </div>
+        <div class="sidebar__section">
+            {% if trait.current_mapping %}
+            <p class="sidebar__section-title">CURATOR</p>
+            <span uk-icon="user" class="uk-margin-small-right"></span>
+            <span class="sidebar__section-text"> {{trait.current_mapping.curator}} </span>
+            <hr/>
+            {% endif %}
+        </div>
+        <div class="sidebar__section">
+            {% if trait.current_mapping %}
+            <p class="sidebar__section-title">REVIEW STATUS</p>
+            {% if trait.current_mapping.is_reviewed %}
+            <span class="uk-label label--success"> REVIEWED</span>
+            {% else %}
+            <span class="uk-label label--warning"> IN REVIEW </span>
+            {% endif %}
+            <button class="uk-button button--success sidebar__section-review-button"> 
+                <span uk-icon="check"> REVIEW </span> 
+            </button>
+            {% endif %}
+        </div>
+    </div>
+</aside>
+
 <div class="uk-container uk-container-xlarge">
     <h1>Trait details</h1>
     <ul class="uk-list">

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -4,6 +4,7 @@
 Trait Detail
 {% endblock %}
 
+{% load trait_filters %}
 {% block content %}
 <aside class="sidebar">
     <div class="sidebar__wrapper">
@@ -36,13 +37,23 @@ Trait Detail
     </div>
 </aside>
 
-<div class="uk-container uk-container-xlarge">
-    <h1>Trait details</h1>
-    <ul class="uk-list">
-        <li>Trait name: {{trait.name}}</li>
-        <li>Source records: {% firstof trait.number_of_source_records '0' %}</li>
-        <li>Trait status: {{trait.status}}</li>
-    </ul>
+<div class="uk-container uk-container-xlarge trait-container">
+    <div class="info-section__wrapper">
+            <div class="info-section__column">
+                <span class="info-section__title">TRAIT NAME</span> 
+                <span class="info-section__value">{{trait.name}} sssssssssssssssssssssssssssss</span>
+            </div>
+            <div class="info-section__column">
+                <span class="info-section__title">SOURCE RECORDS</span> 
+                <span class="info-section__value">{% firstof trait.number_of_source_records '0' %}</span>
+            </div>
+            <div class="info-section__column">
+                <span class="info-section__title">TRAIT STATUS</span> 
+                <span class="uk-label label--{{status_dict | get_dict_item:trait.status}}">
+                    {{trait.status | status_readable_name}}
+                </span>
+            </div>
+    </div>
     <h1>Mapped term details</h1>
     {% with trait.current_mapping.term_id as term %}
     <ul class="uk-list">
@@ -53,5 +64,5 @@ Trait Detail
     {% endwith %}
     
     
-</div>
+</>
 {% endblock %}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -1,68 +1,82 @@
-{% extends "traits/base.html" %}
+{% extends "traits/base.html" %} 
+{% block title %} Trait Detail {% endblock %}
+{% load trait_filters %} 
 
-{% block title %}
-Trait Detail
-{% endblock %}
-
-{% load trait_filters %}
 {% block content %}
 <aside class="sidebar">
-    <div class="sidebar__wrapper">
-        <div class="sidebar__section">
-            <p class="sidebar__section-title">LAST UPDATED</p>
-            <span class="sidebar__section-text"> {{trait.timestamp_updated}} </span>
-            <hr/>
-        </div>
-        <div class="sidebar__section">
-            {% if trait.current_mapping %}
-            <p class="sidebar__section-title">CURATOR</p>
-            <span uk-icon="user" class="uk-margin-small-right"></span>
-            <span class="sidebar__section-text"> {{trait.current_mapping.curator}} </span>
-            <hr/>
-            {% endif %}
-        </div>
-        <div class="sidebar__section">
-            {% if trait.current_mapping %}
-            <p class="sidebar__section-title">REVIEW STATUS</p>
-            {% if trait.current_mapping.is_reviewed %}
-            <span class="uk-label label--success"> REVIEWED</span>
-            {% else %}
-            <span class="uk-label label--warning"> IN REVIEW </span>
-            {% endif %}
-            <button class="uk-button button--success sidebar__section-review-button"> 
-                <span uk-icon="check"> REVIEW </span> 
-            </button>
-            {% endif %}
-        </div>
+  <div class="sidebar__wrapper">
+    <div class="sidebar__section">
+      <p class="sidebar__section-title">LAST UPDATED</p>
+      <span class="sidebar__section-text"> {{trait.timestamp_updated}} </span>
+      <hr />
     </div>
+    <div class="sidebar__section">
+      {% if trait.current_mapping %}
+      <p class="sidebar__section-title">CURATOR</p>
+      <span uk-icon="user" class="uk-margin-small-right"></span>
+      <span class="sidebar__section-text">
+        {{trait.current_mapping.curator}}
+      </span>
+      <hr />
+      {% endif %}
+    </div>
+    <div class="sidebar__section">
+      {% if trait.current_mapping %}
+      <p class="sidebar__section-title">REVIEWED BY</p>
+      {% with trait.current_mapping.review_set.all as reviews %} {% for review
+      in reviews %}
+      <div class="sidebar__review-section">
+        <span uk-icon="user" class="uk-margin-small-right"></span>
+        <span class="sidebar__section-text"> {{review.reviewer}} </span>
+      </div>
+      {% endfor %}
+      <hr />
+      {% endwith %}{% endif %}
+    </div>
+    <div class="sidebar__section">
+      {% if trait.current_mapping %}
+      <p class="sidebar__section-title">REVIEW STATUS</p>
+      {% if trait.current_mapping.is_reviewed %}
+      <span class="uk-label label--success"> REVIEWED</span>
+      {% else %}
+      <span class="uk-label label--warning"> IN REVIEW </span>
+      {% endif %}
+      <button class="uk-button button--success sidebar__section-review-button">
+        <span uk-icon="check"> REVIEW </span>
+      </button>
+      {% endif %}
+    </div>
+  </div>
 </aside>
 
 <div class="uk-container uk-container-xlarge trait-container">
-    <div class="info-section__wrapper">
-            <div class="info-section__column">
-                <span class="info-section__title">TRAIT NAME</span> 
-                <span class="info-section__value">{{trait.name}}</span>
-            </div>
-            <div class="info-section__column">
-                <span class="info-section__title">SOURCE RECORDS</span> 
-                <span class="info-section__value">{% firstof trait.number_of_source_records '0' %}</span>
-            </div>
-            <div class="info-section__column">
-                <span class="info-section__title">TRAIT STATUS</span> 
-                <span class="uk-label label--{{status_dict | get_dict_item:trait.status}}">
-                    {{trait.status | status_readable_name}}
-                </span>
-            </div>
+  <div class="info-section__wrapper">
+    <div class="info-section__column">
+      <span class="info-section__title">TRAIT NAME</span>
+      <span class="info-section__value">{{trait.name}}</span>
     </div>
-    <h1>Mapped term details</h1>
-    {% with trait.current_mapping.term_id as term %}
-    <ul class="uk-list">
-        <li>Term: {% firstof term.curie 'None' %}</li>
-        <li>Term label: {% firstof term.label 'None' %}</li>
-        <li>Term status: {% firstof term.status 'None' %}</li>
-    </ul>
-    {% endwith %}
-    
-    
-</>
+    <div class="info-section__column">
+      <span class="info-section__title">SOURCE RECORDS</span>
+      <span class="info-section__value"
+        >{% firstof trait.number_of_source_records '0' %}</span
+      >
+    </div>
+    <div class="info-section__column">
+      <span class="info-section__title">TRAIT STATUS</span>
+      <span
+        class="uk-label label--{{status_dict | get_dict_item:trait.status}}"
+      >
+        {{trait.status | status_readable_name}}
+      </span>
+    </div>
+  </div>
+  <h1>Mapped term details</h1>
+  {% with trait.current_mapping.term_id as term %}
+  <ul class="uk-list">
+    <li>Term: {% firstof term.curie 'None' %}</li>
+    <li>Term label: {% firstof term.label 'None' %}</li>
+    <li>Term status: {% firstof term.status 'None' %}</li>
+  </ul>
+  {% endwith %}
+</div>
 {% endblock %}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -4,7 +4,6 @@
 
 {% block content %}
 <aside class="sidebar">
-<<<<<<< HEAD
   <div class="sidebar__wrapper">
     <div class="sidebar__section">
       <p class="sidebar__section-title">LAST UPDATED</p>
@@ -24,8 +23,8 @@
     <div class="sidebar__section">
       {% if trait.current_mapping %}
       <p class="sidebar__section-title">REVIEWED BY</p>
-      {% with trait.current_mapping.review_set.all as reviews %} {% for review
-      in reviews %}
+      {% with trait.current_mapping.review_set.all as reviews %} 
+      {% for review in reviews %}
       <div class="sidebar__review-section">
         <span uk-icon="user" class="uk-margin-small-right"></span>
         <span class="sidebar__section-text"> {{review.reviewer}} </span>
@@ -79,54 +78,5 @@
     <li>Term status: {% firstof term.status 'None' %}</li>
   </ul>
   {% endwith %}
-=======
-    <div class="sidebar__wrapper">
-        <div class="sidebar__section">
-            <p class="sidebar__section-title">LAST UPDATED</p>
-            <span class="sidebar__section-text"> {{trait.timestamp_updated}} </span>
-            <hr/>
-        </div>
-        <div class="sidebar__section">
-            {% if trait.current_mapping %}
-            <p class="sidebar__section-title">CURATOR</p>
-            <span uk-icon="user" class="uk-margin-small-right"></span>
-            <span class="sidebar__section-text"> {{trait.current_mapping.curator}} </span>
-            <hr/>
-            {% endif %}
-        </div>
-        <div class="sidebar__section">
-            {% if trait.current_mapping %}
-            <p class="sidebar__section-title">REVIEW STATUS</p>
-            {% if trait.current_mapping.is_reviewed %}
-            <span class="uk-label label--success"> REVIEWED</span>
-            {% else %}
-            <span class="uk-label label--warning"> IN REVIEW </span>
-            {% endif %}
-            <button class="uk-button button--success sidebar__section-review-button"> 
-                <span uk-icon="check"> REVIEW </span> 
-            </button>
-            {% endif %}
-        </div>
-    </div>
-</aside>
-
-<div class="uk-container uk-container-xlarge">
-    <h1>Trait details</h1>
-    <ul class="uk-list">
-        <li>Trait name: {{trait.name}}</li>
-        <li>Source records: {% firstof trait.number_of_source_records '0' %}</li>
-        <li>Trait status: {{trait.status}}</li>
-    </ul>
-    <h1>Mapped term details</h1>
-    {% with trait.current_mapping.term_id as term %}
-    <ul class="uk-list">
-        <li>Term: {% firstof term.curie 'None' %}</li>
-        <li>Term label: {% firstof term.label 'None' %}</li>
-        <li>Term status: {% firstof term.status 'None' %}</li>
-    </ul>
-    {% endwith %}
-    
-    
->>>>>>> 6f49d3d7d78961812843b07ad40473cebd162841
 </div>
 {% endblock %}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -41,7 +41,7 @@ Trait Detail
     <div class="info-section__wrapper">
             <div class="info-section__column">
                 <span class="info-section__title">TRAIT NAME</span> 
-                <span class="info-section__value">{{trait.name}} sssssssssssssssssssssssssssss</span>
+                <span class="info-section__value">{{trait.name}}</span>
             </div>
             <div class="info-section__column">
                 <span class="info-section__title">SOURCE RECORDS</span> 

--- a/traitcuration/traits/templatetags/trait_filters.py
+++ b/traitcuration/traits/templatetags/trait_filters.py
@@ -5,7 +5,6 @@ register = template.Library()
 
 @register.filter
 def get_dict_item(dictionary, key):
-    print(key)
     attribute_dict = dictionary.get(key)
     return attribute_dict['class']
 

--- a/traitcuration/traits/utils.py
+++ b/traitcuration/traits/utils.py
@@ -1,4 +1,4 @@
-def get_status_dict(traits):
+def get_status_dict(traits=[]):
     status_dict = {
         "all": {"count": len(traits), "class": "primary"},
         "awaiting_review": {"count": 0, "class": "warning"},

--- a/traitcuration/traits/views.py
+++ b/traitcuration/traits/views.py
@@ -12,5 +12,6 @@ def browse(request):
 
 def trait_detail(request, pk):
     trait = get_object_or_404(Trait, pk=pk)
-    context = {"trait": trait}
+    status_dict = get_status_dict()
+    context = {"trait": trait, "status_dict": status_dict}
     return render(request, 'traits/trait_detail.html', context)


### PR DESCRIPTION
This PR adds a sidebar which shows review information and the timestamp of a trait's last update, as per the Figma prototype. It also adds clear display of a trait's main information

Closes #21, closes #24