### PR TITLE
Trait history section and date object formatting

### DIFF
--- a/traitcuration/static/js/mapping.js
+++ b/traitcuration/static/js/mapping.js
@@ -143,6 +143,8 @@ function commentButtonClicked() {
     showNotification("The comment form is empty", "warning")
     return;
   }
+  // Empty the textarea once the comment has been submitted
+  document.querySelector('#commentBody').value = "";
   axios
     .post(`/traits/${currentTraitId}/comment`, {
       comment_body: commentBody,

--- a/traitcuration/static/js/mapping.js
+++ b/traitcuration/static/js/mapping.js
@@ -136,3 +136,20 @@ function reviewButtonClicked() {
     });
 }
 
+
+function commentButtonClicked() {
+  commentBody = document.querySelector('#commentBody').value;
+  if (commentBody.trim().length === 0) {
+    showNotification("The comment form is empty", "warning")
+    return;
+  }
+  axios
+    .post(`/traits/${currentTraitId}/comment`, {
+      comment_body: commentBody,
+    })
+    .then((response) => {
+      // handle success
+      console.log(response);
+      location.reload();
+    });
+}

--- a/traitcuration/static/js/time-helper.js
+++ b/traitcuration/static/js/time-helper.js
@@ -1,6 +1,7 @@
 // This module contains utilities for date formatting and output.
 
-const timeFormat = "MMMM Do YYYY, H:MM ";
+
+const timeFormat = "MMMM Do YYYY, H:mm"; // e.g. July 29th 2020, 14:25
 
 // Uses moment.js library to format a ISO formatted date string
 function formatDate(isoformat_timestamp) {

--- a/traitcuration/static/js/time-helper.js
+++ b/traitcuration/static/js/time-helper.js
@@ -1,6 +1,6 @@
 // This module contains utilities for date formatting and output.
 
-const timeFormat = "MMMM Do YYYY, h:mm a";
+const timeFormat = "MMMM Do YYYY, H:MM ";
 
 // Uses moment.js library to format a ISO formatted date string
 function formatDate(isoformat_timestamp) {

--- a/traitcuration/static/js/time-helper.js
+++ b/traitcuration/static/js/time-helper.js
@@ -1,0 +1,19 @@
+// This module contains utilities for date formatting and output.
+
+const timeFormat = "MMMM Do YYYY, h:mm a";
+
+// Uses moment.js library to format a ISO formatted date string
+function formatDate(isoformat_timestamp) {
+  const momentObj = moment(isoformat_timestamp);
+  return momentObj.format(timeFormat);
+}
+
+
+// Queries elements containing dates and appends the formatted date strings to their HTML
+function outputDates() {
+  const elements = document.querySelectorAll(".date");
+
+  for (const element of elements) {
+    element.innerHTML = formatDate(element.getAttribute("date"));
+  }
+}

--- a/traitcuration/static/styles/components/buttons/_buttons.scss
+++ b/traitcuration/static/styles/components/buttons/_buttons.scss
@@ -3,7 +3,7 @@
 .button {
   display: flex !important;
   align-items: center !important;
-  box-shadow: 2px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23) !important;
 
   &--success {
     background-color: $color-success !important;
@@ -30,6 +30,7 @@
   &--disabled {
     background: rgba(255,255,255,0.2) !important;
     padding: 0 1rem !important;
+    box-shadow: none !important;
   }
 }
 .button-outlined {

--- a/traitcuration/static/styles/pages/base/_base.scss
+++ b/traitcuration/static/styles/pages/base/_base.scss
@@ -5,5 +5,5 @@
 }
 
 .section {
-    margin-top: 1.75rem;
+    margin-top: 3rem;
 }

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -65,7 +65,7 @@
     margin-right: 3.75rem;
     display: flex;
     align-items: center;
-    margin-bottom: 1.5rem;;
+    margin-bottom: 1.5rem;
   }
 
   &__title {
@@ -87,7 +87,6 @@
   }
 }
 
-
 .new_term {
   margin-top: 1.25rem;
 
@@ -99,8 +98,7 @@
 .fields {
   display: flex;
   flex-wrap: wrap;
-  margin-top: 1.25rem; 
-
+  margin-top: 1.25rem;
 }
 
 .field {
@@ -111,7 +109,7 @@
   &__text-area {
     height: 11.25rem !important;
   }
-  
+
   &__container {
     margin-right: 2.5rem;
     display: flex;
@@ -119,9 +117,7 @@
   }
 }
 
-
 .post-comment {
-
   &__container {
     border-left: 1px solid $color-primary;
     margin-bottom: 2rem;
@@ -165,4 +161,23 @@
   border-left: 1px solid lighten($color-gray, 20%);
   font-family: $lato;
   margin-bottom: 1.3rem;
+}
+
+.event {
+  border-left: 1px solid lighten($color-gray, 25%);
+  padding-left: 1.5rem;
+  margin-bottom: 2rem;
+  
+  &__date {
+    color: $color-gray;
+  }
+
+  &__title {
+    font-family: $lato-bold !important;
+  }
+  
+  &--comment {
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+  }
 }

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -148,10 +148,12 @@
     resize: none;
     width: 100%;
     height: 2rem;
+    overflow: hidden !important;
     transition: height 0.3s ease !important;
 
     &:focus {
       height: 6rem;
+      overflow-y: scroll !important;
     }
   }
 }

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -1,5 +1,6 @@
 .trait-container {
   width: 83vw;
+  margin-bottom: 2rem;
 }
 
 .info-section {
@@ -116,4 +117,52 @@
     display: flex;
     flex-direction: column;
   }
+}
+
+
+.post-comment {
+
+  &__container {
+    border-left: 1px solid $color-primary;
+    margin-bottom: 2rem;
+    display: grid;
+    gap: 0.7rem;
+    grid-template-rows: auto 1fr;
+    max-height: 10rem;
+    max-width: 50vw;
+    padding: 0.4rem;
+    padding-left: 1rem;
+  }
+
+  &__header {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    padding-left: 0.4rem;
+    gap: 0.8rem;
+    font-family: $lato-bold;
+    align-items: center;
+  }
+
+  &__submit {
+    font-family: $lato !important;
+    justify-self: end;
+  }
+
+  &__textarea {
+    resize: none;
+    width: 100%;
+    height: 2rem;
+    transition: height 0.3s ease !important;
+
+    &:focus {
+      height: 6rem;
+    }
+  }
+}
+
+.comment {
+  padding: 0.8rem;
+  border-left: 1px solid lighten($color-gray, 20%);
+  font-family: $lato;
+  margin-bottom: 1.3rem;
 }

--- a/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
+++ b/traitcuration/static/styles/pages/trait_detail/_trait_detail.scss
@@ -119,7 +119,7 @@
 
 .post-comment {
   &__container {
-    border-left: 1px solid $color-primary;
+    // border-left: 1px solid $color-primary;
     margin-bottom: 2rem;
     display: grid;
     gap: 0.7rem;
@@ -127,7 +127,7 @@
     max-height: 10rem;
     max-width: 50vw;
     padding: 0.4rem;
-    padding-left: 1rem;
+    // padding-left: 1rem;
   }
 
   &__header {

--- a/traitcuration/static/styles/utilities/_utilities.scss
+++ b/traitcuration/static/styles/utilities/_utilities.scss
@@ -5,3 +5,7 @@
 .hidden {
     display: none !important;
 }
+
+.bold {
+    font-family: $lato-bold;
+}

--- a/traitcuration/traits/datasources/dummy.py
+++ b/traitcuration/traits/datasources/dummy.py
@@ -1,10 +1,11 @@
 """
 This module holds dummy data to import during development
 """
-from ..models import OntologyTerm, MappingSuggestion, Trait, Mapping, User, Review, Status
+from ..models import OntologyTerm, MappingSuggestion, Trait, Mapping, User, Review, Status, Comment
 
 
 def import_dummy_data():
+    Comment.objects.all().delete()
     Review.objects.all().delete()
     MappingSuggestion.objects.all().delete()
     Mapping.objects.all().delete()

--- a/traitcuration/traits/templates/traits/base.html
+++ b/traitcuration/traits/templates/traits/base.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
-<body>
+<body onload="outputDates()">
     <nav class="uk-navbar-container header" uk-sticky uk-navbar>
         <div class="uk-navbar-left">
             {% with request.resolver_match.url_name as url_name %}

--- a/traitcuration/traits/templates/traits/base.html
+++ b/traitcuration/traits/templates/traits/base.html
@@ -14,7 +14,9 @@
     <script src="https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/js/uikit-icons.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js"></script>
     <script src="{% static 'js/axios-config.js' %}"></script>
+    <script src="{% static 'js/time-helper.js' %}"></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% block title %}{% endblock %}</title>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -259,28 +259,38 @@
 
       {% for event in history_events|dictsortreversed:"date" %}
       {% if event.type == 'comment' %}
-      <div class="event event--comment">
-        <span class="event__title">{{event.content.author.get_full_name}} commented</span>
-        <span date="{{event.date.isoformat}}" class="date event__date"></span>
-        <p>{{event.content.body}}</p>
+      <div class="event"">
+        <p> 
+          <span class="bold" > {{event.content.author.get_full_name}}</span> commented on 
+          <span date="{{event.date.isoformat}}" class="date bold"></span>
+        </p>
+        <p>
+          {{event.content.body}}
+        </p>
       </div>
 
       {% elif event.type == 'review' %}
-      <div class="event">
-        <p class="event__title"> 
-          {{event.content.reviewer.get_full_name}} reviewed mapping of trait "{{trait.name}}"
-          to term "{{event.content.mapping_id.term_id.curie}} - {{event.content.mapping_id.term_id.label}}"
+      <div class="event"">
+        <p> 
+          <span class="bold" > {{event.content.reviewer.get_full_name}}</span> confirmed the mapping on 
+          <span date="{{event.date.isoformat}}" class="date bold"></span>
         </p>
-        <span date="{{event.date.isoformat}}" class="date event__date"></span>
+        <p>
+          <a href="{{event.content.term_id.iri}}">{{event.content.mapping_id.term_id.curie}}</a> — 
+          <span class="bold"> {{trait.name}}</span>
+        </p>
       </div>
 
       {% elif event.type == 'mapping' %}
       <div class="event"">
-        <p class="event__title"> 
-          {{event.content.curator.get_full_name}} mapped trait 
-          "{{trait.name}}" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}"
+        <p> 
+          <span class="bold" > {{event.content.curator.get_full_name}}</span>  proposed a mapping on 
+          <span date="{{event.date.isoformat}}" class="date bold"></span>
         </p>
-        <span date="{{event.date.isoformat}}" class="date event__date"></span>
+        <p>
+          <a href="{{event.content.term_id.iri}}">{{event.content.term_id.curie}}</a> — 
+          <span class="bold"> {{trait.name}}</span>
+        </p>
       </div>
 
       {% endif %}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -236,6 +236,44 @@
       </div>
     </section>
     {% endif %}
+    <section class="section">
+      <h4>TRAIT HISTORY</h4>
+
+      <div class="post-comment__container">
+        <div class="post-comment__header">
+          <span uk-icon="user"></span>
+          <span>Comment as {{user.get_full_name}}</span>
+          <button class="uk-button button--primary post-comment__submit" onclick="commentButtonClicked()">Submit</button>
+        </div>
+
+        <div class="post-comment__body">
+          <textarea id="commentBody" class="uk-textarea post-comment__textarea" placeholder="Leave a commment...">
+          </textarea>
+        </div>
+      </div>
+      
+
+      {% for comment in trait.comment_set.all|dictsortreversed:"date" %}
+      <div class="uk-comment comment">
+        <header class="uk-comment-header">
+            <div class="uk-grid-medium uk-flex-middle" uk-grid>
+                <div class="uk-width-auto">
+                </div>
+                <div class="uk-width-expand">
+                    <h4 class="uk-comment-title uk-margin-remove">{{comment.author.get_full_name}}</h4>
+                    <ul class="uk-comment-meta uk-subnav uk-subnav-divider uk-margin-remove-top">
+                        <li>{{comment.date}}</li>
+                    </ul>
+                </div>
+            </div>
+        </header>
+        <div class="uk-comment-body">
+            <p>{{comment.body}} </p>
+        </div>
+      </div>
+
+      {% endfor %}
+    </section>
   </div>
 </div>
 

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -143,7 +143,12 @@
           <tr 
           onclick="selectRow(this, 'newSuggestionTable', '{{trait.id}}', '{{suggestion.term_id.id}}')"
           class="suggestion-table__row 
-          {% if suggestion.term_id == current_term%} suggestion-table__row--current {% endif %}">
+          {% if suggestion.term_id == current_term and trait.current_mapping.is_reviewed %} 
+          suggestion-table__row--current 
+          {% endif %}
+          {% if suggestion.term_id == current_term and not trait.current_mapping.is_reviewed %} 
+          suggestion-table__row--awaiting_review 
+          {% endif %}">
             <td>
               <span class="suggestion-table__link">
                 {{suggestion.term_id.label}} 

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -289,7 +289,7 @@
         </p>
         <p>
           <a href="{{event.content.term_id.iri}}">{{event.content.term_id.curie}}</a> — 
-          <span class="bold"> {{trait.name}}</span>
+          <span class="bold"> {{event.content.term_id.label}}</span>
         </p>
       </div>
 

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -10,7 +10,7 @@
   <div class="sidebar__wrapper">
     <div class="sidebar__section">
       <p class="sidebar__section-title">LAST UPDATED</p>
-      <span class="sidebar__section-text"> {{trait.timestamp_updated}} </span>
+      <span date="{{trait.timestamp_updated.isoformat}}" class="date sidebar__section-text"> </span>
       <hr />
     </div>
     <div class="sidebar__section">
@@ -236,6 +236,7 @@
       </div>
     </section>
     {% endif %}
+
     <section class="section">
       <h4>TRAIT HISTORY</h4>
 
@@ -260,7 +261,7 @@
       {% if event.type == 'comment' %}
       <div class="event event--comment">
         <span class="event__title">{{event.content.author.get_full_name}} commented</span>
-        <span class="event__date">{{event.content.date}}</span>
+        <span date="{{event.date.isoformat}}" class="date event__date"></span>
         <p>{{event.content.body}}</p>
       </div>
 
@@ -270,7 +271,7 @@
           {{event.content.reviewer.get_full_name}} reviewed mapping of trait "{{trait.name}}"
           to term "{{event.content.mapping_id.term_id.label}}"
         </p>
-        <span class="event__date">{{event.date}}</span>
+        <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>
 
       {% elif event.type == 'mapping' %}
@@ -279,7 +280,7 @@
           {{event.content.curator.get_full_name}} mapped trait 
           "{{trait.name}}"" to term "{{event.content.term_id.label}}""
         </p>
-        <span class="event__date">{{event.date}}</span>
+        <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>
 
       {% endif %}
@@ -291,6 +292,7 @@
 
 <script src="{% static 'js/mapping.js' %}"></script>
 <script>
-  setCurrentTraitId("{{trait.id}}")
+  setCurrentTraitId("{{trait.id}}");
+  outputDates();
 </script>
 {% endblock %}

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -239,6 +239,7 @@
     <section class="section">
       <h4>TRAIT HISTORY</h4>
 
+      {% if not user.is_anonymous %}
       <div class="post-comment__container">
         <div class="post-comment__header">
           <span uk-icon="user"></span>
@@ -247,30 +248,40 @@
         </div>
 
         <div class="post-comment__body">
-          <textarea id="commentBody" class="uk-textarea post-comment__textarea" placeholder="Leave a commment...">
-          </textarea>
+          <textarea 
+          id="commentBody" 
+          class="uk-textarea post-comment__textarea" 
+          placeholder="Leave a commment..."></textarea>
         </div>
       </div>
-      
+      {% endif%}
 
-      {% for comment in trait.comment_set.all|dictsortreversed:"date" %}
-      <div class="uk-comment comment">
-        <header class="uk-comment-header">
-            <div class="uk-grid-medium uk-flex-middle" uk-grid>
-                <div class="uk-width-auto">
-                </div>
-                <div class="uk-width-expand">
-                    <h4 class="uk-comment-title uk-margin-remove">{{comment.author.get_full_name}}</h4>
-                    <ul class="uk-comment-meta uk-subnav uk-subnav-divider uk-margin-remove-top">
-                        <li>{{comment.date}}</li>
-                    </ul>
-                </div>
-            </div>
-        </header>
-        <div class="uk-comment-body">
-            <p>{{comment.body}} </p>
-        </div>
+      {% for event in history_events|dictsortreversed:"date" %}
+      {% if event.type == 'comment' %}
+      <div class="event event--comment">
+        <span class="event__title">{{event.content.author.get_full_name}} commented</span>
+        <span class="event__date">{{event.content.date}}</span>
+        <p>{{event.content.body}}</p>
       </div>
+
+      {% elif event.type == 'review' %}
+      <div class="event">
+        <p class="event__title"> 
+          {{event.content.reviewer.get_full_name}} reviewed mapping of trait {{trait.name}} 
+          to term {{event.content.mapping_id.term_id.label}}
+        </p>
+        <span class="event__date">{{event.date}}</span>
+      </div>
+
+      {% elif event.type == 'mapping' %}
+      <div class="event"">
+        <p class="event__title"> 
+          {{event.content.curator.get_full_name}} mapped trait {{trait.name}} to term {{event.content.term_id.label}}
+        </p>
+        <span class="event__date">{{event.date}}</span>
+      </div>
+
+      {% endif %}
 
       {% endfor %}
     </section>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -267,8 +267,8 @@
       {% elif event.type == 'review' %}
       <div class="event">
         <p class="event__title"> 
-          {{event.content.reviewer.get_full_name}} reviewed mapping of trait {{trait.name}} 
-          to term {{event.content.mapping_id.term_id.label}}
+          {{event.content.reviewer.get_full_name}} reviewed mapping of trait "{{trait.name}}"
+          to term "{{event.content.mapping_id.term_id.label}}"
         </p>
         <span class="event__date">{{event.date}}</span>
       </div>
@@ -276,7 +276,8 @@
       {% elif event.type == 'mapping' %}
       <div class="event"">
         <p class="event__title"> 
-          {{event.content.curator.get_full_name}} mapped trait {{trait.name}} to term {{event.content.term_id.label}}
+          {{event.content.curator.get_full_name}} mapped trait 
+          "{{trait.name}}"" to term "{{event.content.term_id.label}}""
         </p>
         <span class="event__date">{{event.date}}</span>
       </div>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -278,7 +278,7 @@
       <div class="event"">
         <p class="event__title"> 
           {{event.content.curator.get_full_name}} mapped trait 
-          "{{trait.name}}"" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}""
+          "{{trait.name}}" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}""
         </p>
         <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -276,8 +276,12 @@
           <span date="{{event.date.isoformat}}" class="date bold"></span>
         </p>
         <p>
-          <a href="{{event.content.term_id.iri}}">{{event.content.mapping_id.term_id.curie}}</a> — 
-          <span class="bold"> {{trait.name}}</span>
+          {% if event.content.mapping_id.term_id.iri %}
+          <a target="_blank" href="{{ event.content.mapping_id.term_id.iri }}">
+            {{event.content.mapping_id.term_id.curie}}
+          </a>  —
+          {% endif %}
+          <span class="bold"> {{event.content.mapping_id.term_id.label}}</span>
         </p>
       </div>
 
@@ -288,7 +292,11 @@
           <span date="{{event.date.isoformat}}" class="date bold"></span>
         </p>
         <p>
-          <a href="{{event.content.term_id.iri}}">{{event.content.term_id.curie}}</a> — 
+          {% if event.content.term_id.iri %}
+          <a target="_blank" href="{{ event.content.term_id.iri }}">
+            {{event.content.term_id.curie}}
+          </a> —
+          {% endif %}
           <span class="bold"> {{event.content.term_id.label}}</span>
         </p>
       </div>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -278,7 +278,7 @@
       <div class="event"">
         <p class="event__title"> 
           {{event.content.curator.get_full_name}} mapped trait 
-          "{{trait.name}}" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}""
+          "{{trait.name}}" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}"
         </p>
         <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -48,7 +48,7 @@
           {% if user.email in reviewer_emails %}
           <button class="uk-button button button--disabled sidebar__section-review-button" disabled> REVIEWED </button>
           {% else %}
-          <button class="uk-button button--success sidebar__section-review-button" onclick="reviewButtonClicked()">
+          <button class="uk-button button button--success sidebar__section-review-button" onclick="reviewButtonClicked()">
             <span uk-icon="check"> REVIEW </span>
           </button>
           {% endif %}
@@ -244,7 +244,7 @@
         <div class="post-comment__header">
           <span uk-icon="user"></span>
           <span>Comment as {{user.get_full_name}}</span>
-          <button class="uk-button button--primary post-comment__submit" onclick="commentButtonClicked()">Submit</button>
+          <button class="uk-button button button--primary post-comment__submit" onclick="commentButtonClicked()">Submit</button>
         </div>
 
         <div class="post-comment__body">

--- a/traitcuration/traits/templates/traits/trait_detail.html
+++ b/traitcuration/traits/templates/traits/trait_detail.html
@@ -269,7 +269,7 @@
       <div class="event">
         <p class="event__title"> 
           {{event.content.reviewer.get_full_name}} reviewed mapping of trait "{{trait.name}}"
-          to term "{{event.content.mapping_id.term_id.label}}"
+          to term "{{event.content.mapping_id.term_id.curie}} - {{event.content.mapping_id.term_id.label}}"
         </p>
         <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>
@@ -278,7 +278,7 @@
       <div class="event"">
         <p class="event__title"> 
           {{event.content.curator.get_full_name}} mapped trait 
-          "{{trait.name}}"" to term "{{event.content.term_id.label}}""
+          "{{trait.name}}"" to term "{{event.content.term_id.curie}} - {{event.content.term_id.label}}""
         </p>
         <span date="{{event.date.isoformat}}" class="date event__date"></span>
       </div>

--- a/traitcuration/traits/urls.py
+++ b/traitcuration/traits/urls.py
@@ -4,6 +4,7 @@ from django.urls import path, include
 urlpatterns = [
     path('', views.browse, name="browse"),
     path('<int:pk>/', views.trait_detail, name="trait_detail"),
+    path('<int:pk>/comment', views.comment, name="comment"),
     path('<int:pk>/mapping', views.update_mapping, name='update_mapping'),
     path('<int:pk>/mapping/add', views.add_mapping, name='add_mapping'),
     path('<int:pk>/mapping/review', views.review, name='review'),

--- a/traitcuration/traits/views.py
+++ b/traitcuration/traits/views.py
@@ -26,11 +26,20 @@ def trait_detail(request, pk):
     if trait.current_mapping is not None:
         for review in trait.current_mapping.review_set.all():
             reviewer_emails.append(review.reviewer.email)
-    print(reviewer_emails)
     status_dict = get_status_dict()
+    history_events = list()
+    comments = trait.comment_set.all()
+    for comment in comments:
+        history_events.append({'type': 'comment', 'date': comment.date, 'content': comment})
+    mappings = trait.mapping_set.all()
+    for mapping in mappings:
+        history_events.append({'type': 'mapping', 'date': mapping.timestamp_mapped, 'content': mapping})
+        reviews = mapping.review_set.all()
+        for review in reviews:
+            history_events.append({'type': 'review', 'date': mapping.timestamp_mapped, 'content': review})
     new_term_form = NewTermForm()
     context = {"trait": trait, "status_dict": status_dict,
-               "new_term_form": new_term_form, "reviewer_emails": reviewer_emails}
+               "new_term_form": new_term_form, "reviewer_emails": reviewer_emails, "history_events": history_events}
     return render(request, 'traits/trait_detail.html', context)
 
 

--- a/traitcuration/traits/views.py
+++ b/traitcuration/traits/views.py
@@ -36,7 +36,7 @@ def trait_detail(request, pk):
         history_events.append({'type': 'mapping', 'date': mapping.timestamp_mapped, 'content': mapping})
         reviews = mapping.review_set.all()
         for review in reviews:
-            history_events.append({'type': 'review', 'date': mapping.timestamp_mapped, 'content': review})
+            history_events.append({'type': 'review', 'date': review.timestamp, 'content': review})
     new_term_form = NewTermForm()
     context = {"trait": trait, "status_dict": status_dict,
                "new_term_form": new_term_form, "reviewer_emails": reviewer_emails, "history_events": history_events}


### PR DESCRIPTION
This PR adds a history section that contains information about comments, reviews and mappings of a trait. Also adds date formatting and outputting in the browser's timezone. Closes #28, closes #29, closes #57.