### PR TITLE
Automatic mapping functionality and OxO queries

### DIFF
--- a/traitcuration/traits/datasources/clinvar.py
+++ b/traitcuration/traits/datasources/clinvar.py
@@ -16,7 +16,7 @@ from ..models import Trait, Status
 # Constants to use. URL defines the clinvar data location and NUMBER_OF_RECORDS defines how many traits to parse
 # during development.
 URL = 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz'
-NUMBER_OF_RECORDS = 200
+NUMBER_OF_RECORDS = 1000
 
 logging.basicConfig()
 logger = logging.getLogger('CLINVAR')

--- a/traitcuration/traits/datasources/ols.py
+++ b/traitcuration/traits/datasources/ols.py
@@ -14,7 +14,7 @@ logger.setLevel(logging.INFO)
 BASE_URL = "https://www.ebi.ac.uk/ols/api/"
 
 
-@retry(tries=10, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)
+@retry(tries=3, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)
 def make_ols_query(identifier_value, ontology_id, identifier_type='iri'):
     """
     Takes in an identifier type (iri or curie), the value for that indenrifier to query for, and the ontology id to
@@ -32,10 +32,11 @@ def make_ols_query(identifier_value, ontology_id, identifier_type='iri'):
 
 def parse_ols_results(results):
     term_info = results["_embedded"]["terms"][0]
+    term_iri = term_info["iri"]  # E.g. http://www.ebi.ac.uk/efo/EFO_0000400
     term_curie = term_info["obo_id"]  # E.g. EFO:0000400
     term_label = term_info["label"]  # E.g. Diabetes mellitus
     term_is_obsolete = term_info["is_obsolete"]  # True or False value on whether the term is obsolete or not
-    info_dict = {"curie": term_curie, "label": term_label, "is_obsolete": term_is_obsolete}
+    info_dict = {"curie": term_curie, "iri": term_iri, "label": term_label, "is_obsolete": term_is_obsolete}
     return info_dict
 
 

--- a/traitcuration/traits/datasources/oxo.py
+++ b/traitcuration/traits/datasources/oxo.py
@@ -1,0 +1,20 @@
+import requests
+import logging
+
+from retry import retry
+
+logging.basicConfig()
+logger = logging.getLogger('OXO')
+logger.setLevel(logging.INFO)
+
+BASE_URL = "'https://www.ebi.ac.uk/spot/oxo/api/search?size=5000'"
+
+
+@retry(tries=10, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)
+def make_oxo_query(ids, mapping_target, distance):
+    payload = {}
+    payload['ids'] = ids
+    payload['mappingTarget'] = mapping_target
+    payload['distance'] = distance
+    result = requests.post(BASE_URL, data=payload).json()
+    return result

--- a/traitcuration/traits/datasources/oxo.py
+++ b/traitcuration/traits/datasources/oxo.py
@@ -7,11 +7,11 @@ logging.basicConfig()
 logger = logging.getLogger('OXO')
 logger.setLevel(logging.INFO)
 
-BASE_URL = "'https://www.ebi.ac.uk/spot/oxo/api/search?size=5000'"
+BASE_URL = 'https://www.ebi.ac.uk/spot/oxo/api/search?size=5000'
 
 
 @retry(tries=10, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)
-def make_oxo_query(ids, mapping_target, distance):
+def make_oxo_query(ids, mapping_target='Orphanet,efo,hp,mondo', distance=2):
     payload = {}
     payload['ids'] = ids
     payload['mappingTarget'] = mapping_target

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -167,7 +167,7 @@ def find_automatic_mapping(trait, created_terms, high_confidence_term_iris):
         oxo_results = make_oxo_query([term_curie])
         for result in oxo_results['_embedded']['searchResults'][0]['mappingResponseList']:
             result_iri = make_ols_query(identifier_value=result['curie'],
-                                        ontology_id=ontology_id, identifier_type='curie')['iri']
+                                        ontology_id=ontology_id, identifier_type='obo_id')['iri']
             suggested_term = create_local_term(result_iri)
             created_terms.add(suggested_term)
             create_mapping_suggestion(trait, suggested_term)

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -5,13 +5,7 @@ terms in the app's database.
 import requests
 import logging
 
-<<<<<<< HEAD
-from django.db import transaction
-
-from ..models import Trait, MappingSuggestion, OntologyTerm, User, Status
-=======
 from ..models import Trait, MappingSuggestion, OntologyTerm, User, Status, Mapping
->>>>>>> Create initial automatic mapping functionality
 from .ols import make_ols_query, get_ontology_id
 
 logging.basicConfig()
@@ -35,25 +29,35 @@ def run_zooma_for_single_trait(trait):
     logger.info(f"Retrieving ZOOMA suggestions for trait: {trait.name}")
 
     datasource_suggestion_list = get_suggestions_from_datasources(trait)
+    # for dsl in datasource_suggestion_list:
+    #     print(dsl["semanticTags"][0])
+    #     print(dsl['confidence'])
+
+    # print('--------------------------------------')
     ols_suggestion_list = get_suggestions_from_ols(trait)
+    # for osl in ols_suggestion_list:
+    #     print(osl["semanticTags"][0])
+    #     print(osl['confidence'])
 
-    confidence_dict = dict()  # A dictionary of 'term label' and 'confidence' pairs used to find 'HIGH' conf mappings
-    final_suggestion_iri_set = set()  # A set of the term iris which are kept from the ZOOMA queries
-
+    confidence_dict = dict()
+    final_suggestion_iri_set = set()
     for suggestion in datasource_suggestion_list + ols_suggestion_list:
-        if len(suggestion["semanticTags"]) > 1:
-            logger.warn("Suggestion with combined terms found! Skipping suggestion...")
-            continue
         suggested_term_iri = suggestion["semanticTags"][0]  # E.g. http://purl.obolibrary.org/obo/HP_0004839
         confidence_dict.setdefault(suggested_term_iri, suggestion['confidence'])
         if get_ontology_id(suggested_term_iri) in ["efo", "ordo", "hp", "mondo"]:
             final_suggestion_iri_set.add(suggested_term_iri)
 
+    # print(confidence_dict)
+    print(final_suggestion_iri_set)
+    # A set of suggested terms found in the query and created in the app's database, used to exclude those terms from
+    # being deleted from the database when the delete_unused_mappings function is called.
     created_terms = set()
     for suggested_iri in final_suggestion_iri_set:
         suggested_term = create_local_term(suggested_iri)
         created_terms.add(suggested_term)
         create_mapping_suggestion(trait, suggested_term)
+    print("LENGTH")
+    print(len(created_terms))
     delete_unused_suggestions(trait, created_terms)
     find_automatic_mapping(trait, created_terms, confidence_dict)
 
@@ -144,21 +148,13 @@ def create_mapping_suggestion(trait, term, user_email='eva-dev@ebi.ac.uk'):
     logger.info(f"Created mapping suggestion {suggestion}")
 
 
-<<<<<<< HEAD
-@transaction.atomic
-def delete_unused_suggestions(trait, suggested_terms):
-=======
 def find_automatic_mapping(trait, created_terms, confidence_dict):
-    """
-    If a trait is unmapped, attempts to find an automatic mapping. First if it finds a ZOOMA suggestion with 'HIGH'
-    confidence, then attemps to find an exact text match.
-    """
-
     if trait.status != Status.UNMAPPED:
         return
 
     zooma_user = User.objects.filter(email='eva-dev@ebi.ac.uk').first()
     for term in created_terms:
+        print('EY', confidence_dict.get(term.iri))
         if confidence_dict.get(term.iri) == 'HIGH':
             if Mapping.objects.filter(trait_id=trait, term_id=term).exists():
                 continue
@@ -184,7 +180,6 @@ def find_automatic_mapping(trait, created_terms, confidence_dict):
 
 
 def delete_unused_suggestions(trait, created_terms):
->>>>>>> Create initial automatic mapping functionality
     """
     Takes in a trait and a set of created_terms, found in the previously executed ZOOMA query. This function gets all
     the mapping suggestions for that trait that are NOT found in the created_terms list or in any previous mappings

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -63,7 +63,7 @@ def get_suggestions_from_datasources(trait):
     formatted_trait_name = requests.utils.quote(trait.name)
     response = requests.get(
         f"{BASE_URL}/services/annotate?propertyValue={formatted_trait_name}"
-        "&filter=required:[cttv,sysmicro,atlas,ebisc,uniprot,gwas,cbi]")
+        "&filter=required:[cttv,sysmicro,atlas,ebisc,uniprot,gwas,cbi,clinvar-xrefs]")
     return response.json()
 
 
@@ -162,6 +162,10 @@ def find_automatic_mapping(trait, created_terms, high_confidence_term_iris):
             return
 
     for term_iri in high_confidence_term_iris:
+        print('HEYYYYYYYYYYYYYY1')
+        if 'medgen' in term_iri:
+            print('HEYYYYYYYYYYYYYY2')
+            continue
         ontology_id = get_ontology_id(term_iri)
         term_curie = make_ols_query(identifier_value=term_iri, ontology_id=ontology_id)['curie']
         oxo_results = make_oxo_query([term_curie])

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -5,9 +5,13 @@ terms in the app's database.
 import requests
 import logging
 
+<<<<<<< HEAD
 from django.db import transaction
 
 from ..models import Trait, MappingSuggestion, OntologyTerm, User, Status
+=======
+from ..models import Trait, MappingSuggestion, OntologyTerm, User, Status, Mapping
+>>>>>>> Create initial automatic mapping functionality
 from .ols import make_ols_query, get_ontology_id
 
 logging.basicConfig()
@@ -29,26 +33,62 @@ def run_zooma_for_all_traits():
 
 def run_zooma_for_single_trait(trait):
     logger.info(f"Retrieving ZOOMA suggestions for trait: {trait.name}")
-    suggestion_list = get_zooma_suggestions_for_trait(trait)
-    # A set of suggested terms found in the query, used to exclude those terms from being deleted from the database
-    # when the delete_unused_mappings function is called.
-    suggested_terms = set()
-    for suggestion in suggestion_list:
+
+    datasource_suggestion_list = get_suggestions_from_datasources(trait)
+    # for dsl in datasource_suggestion_list:
+    #     print(dsl["semanticTags"][0])
+    #     print(dsl['confidence'])
+
+    # print('--------------------------------------')
+    ols_suggestion_list = get_suggestions_from_ols(trait)
+    # for osl in ols_suggestion_list:
+    #     print(osl["semanticTags"][0])
+    #     print(osl['confidence'])
+
+    confidence_dict = dict()
+    final_suggestion_iri_set = set()
+    for suggestion in datasource_suggestion_list + ols_suggestion_list:
         suggested_term_iri = suggestion["semanticTags"][0]  # E.g. http://purl.obolibrary.org/obo/HP_0004839
-        suggested_term = create_local_term(suggested_term_iri)
+        confidence_dict.setdefault(suggested_term_iri, suggestion['confidence'])
+        if get_ontology_id(suggested_term_iri) in ["efo", "ordo", "hp", "mondo"]:
+            final_suggestion_iri_set.add(suggested_term_iri)
+
+    # print(confidence_dict)
+    print(final_suggestion_iri_set)
+    # A set of suggested terms found in the query and created in the app's database, used to exclude those terms from
+    # being deleted from the database when the delete_unused_mappings function is called.
+    created_terms = set()
+    for suggested_iri in final_suggestion_iri_set:
+        suggested_term = create_local_term(suggested_iri)
+        created_terms.add(suggested_term)
         create_mapping_suggestion(trait, suggested_term)
-        suggested_terms.add(suggested_term)
-    delete_unused_suggestions(trait, suggested_terms)
+    print("LENGTH")
+    print(len(created_terms))
+    delete_unused_suggestions(trait, created_terms)
+    find_automatic_mapping(trait, created_terms, confidence_dict)
 
 
-def get_zooma_suggestions_for_trait(trait):
+def get_suggestions_from_datasources(trait):
+    """
+    Takes in a trait object as its argument and returns the zooma response of a suggestion list as a dictionary.
+    """
+    formatted_trait_name = trait.name.replace(' ', '+')
+    print(f"{BASE_URL}/services/annotate?propertyValue={formatted_trait_name}"
+          "&filter=required:[cttv,sysmicro,atlas,ebisc,uniprot,gwas,cbi]")
+    response = requests.get(
+        f"{BASE_URL}/services/annotate?propertyValue={formatted_trait_name}"
+        "&filter=required:[cttv,sysmicro,atlas,ebisc,uniprot,gwas,cbi]")
+    return response.json()
+
+
+def get_suggestions_from_ols(trait):
     """
     Takes in a trait object as its argument and returns the zooma response of a suggestion list as a dictionary.
     """
     formatted_trait_name = trait.name.replace(' ', '+')
     response = requests.get(
-        f"{BASE_URL}/services/annotate?propertyValue={formatted_trait_name} \
-        &filter=required:[none],ontologies:[efo,mondo,hp,ordo]")
+        f"{BASE_URL}/services/annotate?propertyValue={formatted_trait_name}"
+        "&filter=required:[none],ontologies:[efo,mondo,hp,ordo]")
     return response.json()
 
 
@@ -114,16 +154,51 @@ def create_mapping_suggestion(trait, term, user_email='eva-dev@ebi.ac.uk'):
     logger.info(f"Created mapping suggestion {suggestion}")
 
 
+<<<<<<< HEAD
 @transaction.atomic
 def delete_unused_suggestions(trait, suggested_terms):
+=======
+def find_automatic_mapping(trait, created_terms, confidence_dict):
+    if trait.status != Status.UNMAPPED:
+        return
+
+    zooma_user = User.objects.filter(email='eva-dev@ebi.ac.uk').first()
+    for term in created_terms:
+        print('EY', confidence_dict.get(term.iri))
+        if confidence_dict.get(term.iri) == 'HIGH':
+            if Mapping.objects.filter(trait_id=trait, term_id=term).exists():
+                continue
+            mapping = Mapping(trait_id=trait, term_id=term,
+                              curator=zooma_user, is_reviewed=False)
+            mapping.save()
+            trait.current_mapping = mapping
+            trait.save()
+            print('CREATED CONF', trait.current_mapping)
+            return
+
+    for term in created_terms:
+        if trait.name.lower() == term.label.lower():
+            if Mapping.objects.filter(trait_id=trait, term_id=term).exists():
+                continue
+            mapping = Mapping(trait_id=trait, term_id=term,
+                              curator=zooma_user, is_reviewed=False)
+            mapping.save()
+            trait.current_mapping = mapping
+            trait.save()
+            print('CREATED TEXT MATCH', trait.current_mapping)
+            return
+
+
+def delete_unused_suggestions(trait, created_terms):
+>>>>>>> Create initial automatic mapping functionality
     """
-    Takes in a trait and a set of suggested_terms, found in the previously executed ZOOMA query. This function gets all
-    the mapping suggestions for that trait that are NOT found in the suggested_terms list or in any previous mappings
+    Takes in a trait and a set of created_terms, found in the previously executed ZOOMA query. This function gets all
+    the mapping suggestions for that trait that are NOT found in the created_terms list or in any previous mappings
     for that trait, and deletes them
     """
     trait_mappings = trait.mapping_set.all()
     for mapping in trait_mappings:
-        suggested_terms.add(mapping.term_id)
-    deleted_suggestions = trait.mappingsuggestion_set.exclude(term_id__in=list(suggested_terms))
+        created_terms.add(mapping.term_id)
+    deleted_suggestions = trait.mappingsuggestion_set.exclude(term_id__in=list(created_terms))
     deleted_suggestions.delete()
-    logger.info(f"Deleted mapping suggestions {deleted_suggestions}")
+    logger.info(f"Deleted mapping suggestions {deleted_suggestions.all()}")

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -146,8 +146,8 @@ def find_automatic_mapping(trait, created_terms, high_confidence_term_iris):
     confidence, then attemps to find an exact text match.
     """
 
-    if trait.status != Status.UNMAPPED:
-        return
+    # if trait.status != Status.UNMAPPED:
+    #     return
 
     for term in created_terms:
         if term.iri in high_confidence_term_iris:
@@ -162,18 +162,21 @@ def find_automatic_mapping(trait, created_terms, high_confidence_term_iris):
             return
 
     for term_iri in high_confidence_term_iris:
-        print('HEYYYYYYYYYYYYYY1')
+        # Skip medgen terms since info about them can't be retrieved through OLS
         if 'medgen' in term_iri:
-            print('HEYYYYYYYYYYYYYY2')
             continue
         ontology_id = get_ontology_id(term_iri)
+
         term_curie = make_ols_query(identifier_value=term_iri, ontology_id=ontology_id)['curie']
         oxo_results = make_oxo_query([term_curie])
         for result in oxo_results['_embedded']['searchResults'][0]['mappingResponseList']:
+            ontology_id = result['targetPrefix'].lower()  # E.g. 'efo'
+            if ontology_id == "orphanet":
+                ontology_id = "ordo"
             result_iri = make_ols_query(identifier_value=result['curie'],
                                         ontology_id=ontology_id, identifier_type='obo_id')['iri']
             suggested_term = create_local_term(result_iri)
-            created_terms.add(suggested_term)
+            created_terms.append(suggested_term)
             create_mapping_suggestion(trait, suggested_term)
 
 


### PR DESCRIPTION
This PR adds mapping traits to term suggestions automatically, and creating new suggestions based on OxO queries. Pipeline logic:
1. If a term suggestion is of 'HIGH' confidence and is in EFO compatible ontologies, map it automatically to the trait.
2. If a term suggestion is an exact text match with the trait, map it automatically.
3.  If a term suggestion is of 'HIGH' confidence and is *8not** in EFO compatible ontologies, find its cross-refs using OxO, and create mapping suggestions of it, **but don't create a mapping**.

It can be tested by importing traits from ClinVar and then triggering a ZOOMA import.

Closes #44 