### PR TITLE
Update ClinVar parsing script to meet new specifications

### DIFF
--- a/traitcuration/traits/datasources/clinvar.py
+++ b/traitcuration/traits/datasources/clinvar.py
@@ -61,8 +61,12 @@ def parse_trait_names_and_source_records():
         for row in itertools.islice(reader, NUMBER_OF_RECORDS):
             # For every row, get its allele_id and all its rcv_accessions and phenotypes
             row_alleleid = (row['#AlleleID'])
-            row_rcv_list = row['RCVaccession'].split(';')
-            row_phenotype_list = row['PhenotypeList'].split(';')
+            row_rcv_list = row['RCVaccession'].split('|')
+            row_phenotype_list = row['PhenotypeList'].split('|')
+            if '-' in row_phenotype_list:
+                row_phenotype_list.remove('-')
+            if len(row_phenotype_list) > 5:
+                continue
             # Get every possible pair tuple of allele_id rcv_accessions and phenotypes for the current row
             tuple_set = {(row_alleleid, rcv, phenotype) for rcv, phenotype in zip(row_rcv_list, row_phenotype_list)}
             # Insert the tuple in the dictionary


### PR DESCRIPTION
This PR includes three small changes in the ClinVar parsing script based on the updates mentioned in #84 
- Replaced semicolon(';') with pipe('|') as the seperating character for phenotypes and RCV
- Added a check to remove '-' entries in the PhenotypeList column
- Added a check to skip rows that contain more than 5 phenotypes

Closes #84 

A working deployment of this PR is available here: https://trait-curation-pr-94.herokuapp.com/traits/