### PR TITLE
Configuration variables and background task scheduling

### DIFF
--- a/docs/deployment-ubuntu.md
+++ b/docs/deployment-ubuntu.md
@@ -406,8 +406,7 @@ sudo service celeryd start
 ## 9. Daemonize Celery Beat for background task scheduling
 
 1. First, create the configuration file for the `celerybeat` daemon:
-
-```
+```bash
 sudo nano /etc/default/celerybeat
 ```
 
@@ -431,8 +430,7 @@ CELERYBEAT_USER="ubuntu"
 ```
 
 3. Download the generic init script for `celerybeat` daemon, and place it in the `init.d` directory:
-
-```
+```bash
 cd ~
 wget https://raw.githubusercontent.com/celery/celery/3.1/extra/generic-init.d/celerybeat
 sudo chmod +x celerybeat
@@ -440,20 +438,20 @@ sudo mv celerybeat /etc/init.d/celerybeat
 ```
 
 4. Create the logs file and directory, and add the appropriate permissions
-```
+```bash
 mkdir /var/log/celerybeat
 chown -R ubuntu:ubuntu /var/log/celerybeat
 touch /var/log/celerybeat/beat.log
 ```
 
 5. Verbose the init-scripts
-```
+```bash
 sudo sh -x /etc/init.d/celerybeat start
 sudo sh -x /etc/init.d/celerybeat status
 ```
 
 6. Provided you get a successful exit status, enable the daemon
-```
+```bash
 sudo update-rc.d celerybeat defaults
 sudo service celerybeat start
 ```

--- a/docs/deployment-ubuntu.md
+++ b/docs/deployment-ubuntu.md
@@ -403,7 +403,63 @@ sudo update-rc.d celeryd defaults
 sudo service celeryd start
 ```
 
-## 9. Create Google API credentials file
+## 9. Daemonize Celery Beat for background task scheduling
+
+1. First, create the configuration file for the `celerybeat` daemon:
+
+```
+sudo nano /etc/default/celerybeat
+```
+
+2. Add the following configuration:
+```python
+# Absolute or relative path to the 'celery' command:
+CELERY_BIN="/home/ubuntu/trait-curation/traitcurationenv/bin/celery"
+
+# App instance to use
+CELERY_APP="traitcuration"
+
+# Where to chdir at start.
+CELERYBEAT_CHDIR="/home/ubuntu/trait-curation/"
+
+# Extra arguments to celerybeat
+CELERYBEAT_OPTS="--scheduler django_celery_beat.schedulers:DatabaseScheduler"
+
+CELERYBEAT_LOG_FILE="/var/log/celerybeat/beat.log"
+
+CELERYBEAT_USER="ubuntu"
+```
+
+3. Download the generic init script for `celerybeat` daemon, and place it in the `init.d` directory:
+
+```
+cd ~
+wget https://raw.githubusercontent.com/celery/celery/3.1/extra/generic-init.d/celerybeat
+sudo chmod +x celerybeat
+sudo mv celerybeat /etc/init.d/celerybeat
+```
+
+4. Create the logs file and directory, and add the appropriate permissions
+```
+mkdir /var/log/celerybeat
+chown -R ubuntu:ubuntu /var/log/celerybeat
+touch /var/log/celerybeat/beat.log
+```
+
+5. Verbose the init-scripts
+```
+sudo sh -x /etc/init.d/celerybeat start
+sudo sh -x /etc/init.d/celerybeat status
+```
+
+6. Provided you get a successful exit status, enable the daemon
+```
+sudo update-rc.d celerybeat defaults
+sudo service celerybeat start
+```
+
+
+## 10. Create Google API credentials file
 
 In order for the app to create spreadsheets via the `gspread` library, there needs to exist a `service_account.json` file. If you haven't enabled a service account for the app, follow these instructions to do so https://gspread.readthedocs.io/en/latest/oauth2.html#enable-api-access-for-a-project.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ defusedxml==0.6.0
 Deprecated==1.2.10
 dj-database-url==0.5.0
 Django==3.0.7
+django-admin-conf-vars==0.4.1
 django-allauth==0.42.0
 django-appconf==1.0.4
 django-celery-beat==2.0.0

--- a/traitcuration/config_vars.py
+++ b/traitcuration/config_vars.py
@@ -1,0 +1,14 @@
+# -*- coding:utf-8 -*-
+from django_admin_conf_vars.global_vars import config
+
+config.set("CLINVAR_BASE_URL", default='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz')
+config.set("CLINVAR_RECORDS_TO_PARSE", default=1000)
+
+config.set("ZOOMA_BASE_URL", default="http://www.ebi.ac.uk/spot/zooma/v2/api")
+
+config.set("OLS_BASE_URL", default="https://www.ebi.ac.uk/ols/api/")
+
+config.set("OXO_BASE_URL", default="https://www.ebi.ac.uk/spot/oxo/api/search?size=5000")
+config.set("OXO_MAPPING_DISTANCE", default=2)
+
+config.set("REVIEW_MIN_NUMBER", default=2)

--- a/traitcuration/settings.py
+++ b/traitcuration/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.google',
     'computedfields',
     'rest_framework',
+    'django_admin_conf_vars'
 ]
 
 
@@ -193,6 +194,11 @@ CELERY_IMPORTS = (
     'traitcuration.traits.tasks',
     'traitcuration.traits.datasources',
 )
+
+
+# django_admin_conf_vars config
+VARS_MODULE_PATH = 'traitcuration.config_vars'
+
 
 # Local environment config
 if os.environ.get('DJANGO_ENV') == 'LOCAL_DEV':

--- a/traitcuration/settings.py
+++ b/traitcuration/settings.py
@@ -14,6 +14,8 @@ import django_heroku
 import os
 import yaml
 
+from celery.schedules import crontab
+
 try:
     file = open('config.yaml', 'r')
     config = yaml.load(file, Loader=yaml.FullLoader)
@@ -58,7 +60,8 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.google',
     'computedfields',
     'rest_framework',
-    'django_admin_conf_vars'
+    'django_admin_conf_vars',
+    'django_celery_beat',
 ]
 
 
@@ -185,6 +188,7 @@ COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )
 
+
 # Celery config
 CELERY_BROKER_URL = config['DATABASES']['REDIS']['URL']
 CELERY_ACCEPT_CONTENT = ['json']
@@ -194,6 +198,21 @@ CELERY_IMPORTS = (
     'traitcuration.traits.tasks',
     'traitcuration.traits.datasources',
 )
+
+CELERY_BEAT_SCHEDULE = {
+    'import-clinvar-every-thursday': {
+        'task': 'traitcuration.traits.tasks.import_clinvar',
+        'schedule': crontab(hour='9', minute='25', day_of_week='thu'),
+    },
+    'import-zooma-every-thursday': {
+        'task': 'traitcuration.traits.tasks.import_zooma',
+        'schedule': crontab(hour='9', minute='33', day_of_week='thu'),
+    },
+    'update-ols-every-month': {
+        'task': 'traitcuration.traits.tasks.import_ols',
+        'schedule': crontab(0, 0, day_of_month='2')
+    }
+}
 
 
 # django_admin_conf_vars config

--- a/traitcuration/traits/datasources/clinvar.py
+++ b/traitcuration/traits/datasources/clinvar.py
@@ -10,13 +10,14 @@ import logging
 import requests
 
 from django.db import transaction
+from django_admin_conf_vars.global_vars import config
 
 from ..models import Trait, Status
 
 # Constants to use. URL defines the clinvar data location and NUMBER_OF_RECORDS defines how many traits to parse
 # during development.
-URL = 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz'
-NUMBER_OF_RECORDS = 1000
+URL = config.CLINVAR_BASE_URL
+NUMBER_OF_RECORDS = int(config.CLINVAR_RECORDS_TO_PARSE)
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)

--- a/traitcuration/traits/datasources/ols.py
+++ b/traitcuration/traits/datasources/ols.py
@@ -7,6 +7,7 @@ import logging
 from retry import retry
 
 from django.db import transaction
+from django_admin_conf_vars.global_vars import config
 
 from ..models import Status, OntologyTerm
 
@@ -15,7 +16,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-BASE_URL = "https://www.ebi.ac.uk/ols/api/"
+BASE_URL = config.OLS_BASE_URL
 
 
 @retry(tries=3, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)

--- a/traitcuration/traits/datasources/oxo.py
+++ b/traitcuration/traits/datasources/oxo.py
@@ -2,16 +2,18 @@ import requests
 import logging
 
 from retry import retry
+from django_admin_conf_vars.global_vars import config
 
 logging.basicConfig()
 logger = logging.getLogger('OXO')
 logger.setLevel(logging.INFO)
 
-BASE_URL = 'https://www.ebi.ac.uk/spot/oxo/api/search?size=5000'
+BASE_URL = config.OXO_BASE_URL
+MAPPING_DISTANCE = int(config.OXO_MAPPING_DISTANCE)
 
 
 @retry(tries=10, delay=5, backoff=1.2, jitter=(1, 3), logger=logger)
-def make_oxo_query(ids, mapping_target='Orphanet,efo,hp,mondo', distance=2):
+def make_oxo_query(ids, mapping_target='Orphanet,efo,hp,mondo', distance=MAPPING_DISTANCE):
     payload = {}
     payload['ids'] = ids
     payload['mappingTarget'] = mapping_target

--- a/traitcuration/traits/datasources/zooma.py
+++ b/traitcuration/traits/datasources/zooma.py
@@ -6,6 +6,7 @@ import requests
 import logging
 
 from django.db import transaction
+from django_admin_conf_vars.global_vars import config
 
 from ..models import Trait, MappingSuggestion, OntologyTerm, User, Status, Mapping
 from .ols import make_ols_query, get_ontology_id, get_term_status
@@ -16,7 +17,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-BASE_URL = "http://www.ebi.ac.uk/spot/zooma/v2/api"
+BASE_URL = config.ZOOMA_BASE_URL
 
 
 def run_zooma_for_all_traits():

--- a/traitcuration/traits/models.py
+++ b/traitcuration/traits/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.utils.translation import ugettext_lazy as _
+from django_admin_conf_vars.global_vars import config
 from computedfields.models import ComputedFieldsModel, computed
 
 from .managers import CustomUserManager
@@ -89,7 +90,7 @@ class Mapping(ComputedFieldsModel):
         ['review_set', ['mapping_id']],
     ])
     def is_reviewed(self):
-        return self.review_set.count() >= 2
+        return self.review_set.count() >= int(config.REVIEW_MIN_NUMBER)
 
     def __str__(self):
         return f"{self.mapped_trait} - {self.mapped_term}"


### PR DESCRIPTION
This PR adds configuration variables for various functionality of the app, that can be edited via the Django Admin, as well as the ability to schedule background tasks via Celery Beat. The background tasks can also be viewed and edited in the Django Admin.

This branch is deployed in http://trait-curation-2.duckdns.org and is available for testing.

Closes #34 , #50 